### PR TITLE
Set symbol background to standard background color

### DIFF
--- a/usb-c-pill/usb-c-pill.lib
+++ b/usb-c-pill/usb-c-pill.lib
@@ -9,7 +9,7 @@ F1 "weact-black-pill" 0 50 50 H V C CNN
 F2 "usb-c-pill:weact-blackpill" 0 150 50 H I C CNN
 F3 "" 0 150 50 H I C CNN
 DRAW
-S -450 100 450 -2050 0 1 0 N
+S -450 100 450 -2050 0 1 0 f
 X B12 1 -550 -100 100 R 50 50 1 1 B
 X A15 10 -550 -1000 100 R 50 50 1 1 B
 X B3 11 -550 -1100 100 R 50 50 1 1 B
@@ -65,7 +65,7 @@ F1 "weact-black-pill-nodebug" 0 50 50 H V C CNN
 F2 "usb-c-pill:weact-blackpill-nodebug" 0 150 50 H I C CNN
 F3 "" 0 150 50 H I C CNN
 DRAW
-S -450 100 450 -2050 0 1 0 N
+S -450 100 450 -2050 0 1 0 f
 X B12 1 -550 -100 100 R 50 50 1 1 B
 X A15 10 -550 -1000 100 R 50 50 1 1 B
 X B3 11 -550 -1100 100 R 50 50 1 1 B
@@ -117,7 +117,7 @@ F1 "weact-black-pill-swdonly" 0 50 50 H V C CNN
 F2 "usb-c-pill:weact-blackpill-swdonly" 0 150 50 H I C CNN
 F3 "" 0 150 50 H I C CNN
 DRAW
-S -450 100 450 -2050 0 1 0 N
+S -450 100 450 -2050 0 1 0 f
 X B12 1 -550 -100 100 R 50 50 1 1 B
 X A15 10 -550 -1000 100 R 50 50 1 1 B
 X B3 11 -550 -1100 100 R 50 50 1 1 B


### PR DESCRIPTION
Hi :) thanks for the useful kicad lib.

I noticed the background colors of the usb-c-pill symbols are just white and not the default kicad symbol bg color. Smallest PR ever I guess, let me know what you think :)

BTW, I think something may be wrong with the symbol-footprint linking of the nodebug usb-c-pill. Investigating, if I figure it out I'll make another PR.

BTW BTW, do you think the usb-c-pill files could be their own repo? Or is this a grab-bag place :)